### PR TITLE
Make checkbox white in the light Things theme

### DIFF
--- a/input/things/fixes.css
+++ b/input/things/fixes.css
@@ -61,3 +61,8 @@ blockquote:before {
 .text-sm {
   font-size: 1rem;
 }
+
+.white-theme .form-checkbox:checked,
+html[data-theme="light"] .form-checkbox:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='%23ffffff' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M5.707 7.293a1 1 0 0 0-1.414 1.414l2 2a1 1 0 0 0 1.414 0l4-4a1 1 0 0 0-1.414-1.414L7 8.586 5.707 7.293z'/%3e%3c/svg%3e");
+}


### PR DESCRIPTION
Fixes https://github.com/rcvd/logseq-things-theme/issues/11

Before:
<img width="594" alt="Screenshot 2023-05-29 at 12 12 21" src="https://github.com/rcvd/logseq-css-system/assets/234778/c1b25647-94a5-47e6-bdf3-ccfc495f191c">

After:
<img width="594" alt="Screenshot 2023-05-29 at 12 12 35" src="https://github.com/rcvd/logseq-css-system/assets/234778/db90f8e1-7e95-430b-9d2f-f841988eeedf">

Not sure if this is the "correct way" but it does do the job :) please tell me if there's a different preferred way. I hope this helps